### PR TITLE
Improve python 2.6 support

### DIFF
--- a/dataloader.py
+++ b/dataloader.py
@@ -31,7 +31,7 @@ class Loader(object):
             markup = self.markups.get(splitext(path)[-1][1:], self.default_markup)
         if self.log:
             self.log.info('get %s: %s [%s]', name or self.name, path, markup)
-        return self.postprocess(getattr(self, 'load_{}'.format(markup))(f), name, **options)
+        return self.postprocess(getattr(self, 'load_{0}'.format(markup))(f), name, **options)
 
     __call__ = load
 
@@ -66,6 +66,6 @@ class Loader(object):
             return load(f)
 
     def __str__(self):
-        return '{}.{}({}: *{}, {})'.format(self.__class__.__module__, self.__class__.__name__.lower(),
+        return '{0}.{1}({2}: *{3}, {4})'.format(self.__class__.__module__, self.__class__.__name__.lower(),
             self.name, self.default_markup,
             ', '.join(k for k in sorted(set(self.markups.values())) if k != self.default_markup))

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ properties = dict(
     name = 'PyDataLoader',
     version = __version__,
     url = 'https://github.com/salsita/pydataloader',
-    download_url = 'https://github.com/salsita/pydataloader/tarball/v{}'.format( __version__),
+    download_url = 'https://github.com/salsita/pydataloader/tarball/v{0}'.format( __version__),
     description = __doc__.strip().split('\n', 1)[0].strip('.'),
         # First non-empty line of module doc
     long_description = (__doc__.strip() + '\n').split('\n', 1)[1].strip(),


### PR DESCRIPTION
String formatting in python 2.6 does not support using replacement field without name or index. So in Python 2.6 is not possible to use "{}".format(arg), instead of this we should use "{0}".format(arg)
